### PR TITLE
Allow rethrown `RestClient::Exception`s getting catched via CobotClient::Exception

### DIFF
--- a/lib/cobot_client/exceptions.rb
+++ b/lib/cobot_client/exceptions.rb
@@ -5,8 +5,7 @@ module CobotClient
     EXCEPTIONS_MAP = {}
   end
 
-  class Exception < RestClient::Exception
-  end
+  Exception = RestClient::Exception
 
   RestClient::STATUSES.each_pair do |code, message|
     superclass = RestClient::Exceptions::EXCEPTIONS_MAP.fetch code


### PR DESCRIPTION
eg:

```ruby
begin
  api_client.put 'co-up', '/invoices', [{id: '1'}]
rescue CobotClient::Exception => e
  # ...
end
```