### PR TITLE
Repackage JSON::ParserError as CobotClient::MalformedResponseBody error

### DIFF
--- a/lib/cobot_client/errors.rb
+++ b/lib/cobot_client/errors.rb
@@ -44,4 +44,6 @@ module CobotClient
 
     [code.to_i, const_set(class_name, class_object)]
   end
+
+  class MalformedResponseBody < ResponseError; end
 end

--- a/lib/cobot_client/response.rb
+++ b/lib/cobot_client/response.rb
@@ -22,6 +22,8 @@ module CobotClient
       return if !success? || code == 204
 
       JSON.parse(@net_http_response.body, symbolize_names: true)
+    rescue JSON::ParserError => e
+      raise MalformedResponseBody.new("#{e.class}: #{e.message}", response: self)
     end
 
     def client_error?

--- a/spec/cobot_client/api_client_spec.rb
+++ b/spec/cobot_client/api_client_spec.rb
@@ -278,13 +278,27 @@ describe CobotClient::ApiClient do
       error = response.to_error
       allow_any_instance_of(CobotClient::Request).to receive(:submit).and_raise(error)
 
-      begin
-        api_client.get('co-up', '/invoices')
-      rescue CobotClient::ResponseError => e
-        expect(e).to be_a(CobotClient::NotFound)
-        expect(e.response).to eql(response)
-        expect(e.http_code).to be(404)
-        expect(e.http_body).to eql('boom')
+      expect { api_client.get('co-up', '/invoices') }.to raise_error(CobotClient::NotFound) do |e|
+        expect(e).to be_a(CobotClient::Error)
+        expect(e).to be_a(CobotClient::ResponseError)
+        expect(e.response).to eq(response)
+        expect(e.http_code).to eq(404)
+        expect(e.http_body).to eq('boom')
+      end
+    end
+
+    it 'raises a MalformedResponseBody error when the response body is not valid JSON' do
+      stub_request(:get, 'https://co-up.cobot.me/api/invoices')
+        .to_return(status: 200, body: '<invoices></invoices>')
+
+      expect { api_client.get('co-up', '/invoices') }.to raise_error(CobotClient::MalformedResponseBody) do |e|
+        expect(e).to be_a(CobotClient::Error)
+        expect(e).to be_a(CobotClient::ResponseError)
+        expect(e.http_code).to eq(200)
+        expect(e.http_body).to eq('<invoices></invoices>')
+        expect(e.message).to eq(<<~MESSAGE.chomp)
+          HTTP 200 - JSON::ParserError: unexpected character: '<invoices></invoices>' at line 1 column 1
+        MESSAGE
       end
     end
   end


### PR DESCRIPTION
It best Ruby gem fashion all errors raised by the `cobot_client` gem should be subclasses of `CobotClient::Error`. Advantages:

- By default error trackers like HoneyBadger or Sentry usually
  hide the parts   of the error backtrace which are not part
  of the code base at hand. This can make it a bit harder
  to understand what happended when you just see `JSON::ParserError`.
  With repackaging, the developer sees
  `CobotClient::MalformedResponseBody` which is abundantly clear.
- Since `MalformedResponseBody` is an `HttpResponseError` we get
  a lot of debugging convenience since we can directly inspect
  `e.http_body`, `e.http_code`, or even the whole `e.response`.
- The original exception is not lost thanks to Ruby's
  [exception cause mechanism](https://www.honeybadger.io/blog/nested-errors-in-ruby-with-exception-cause/)
  and modern error trackers will list the whole cause chain.

The only sad part about this change is that Cobot maintains flawless API stability and most likely nobody will ever profit from this change.

But hey, better safe than sorry.